### PR TITLE
Adds support for select_classes

### DIFF
--- a/src/main/java/com/clarifai/api/ClarifaiClient.java
+++ b/src/main/java/com/clarifai/api/ClarifaiClient.java
@@ -89,6 +89,20 @@ public class ClarifaiClient {
   }
 
   /**
+   * Makes a recognition request for tags only.
+   * This supports the select_classes feature to request the probabilities for specific tag for the given image(s) with {@link RecognitionRequest#addTagForSelectClasses(String)}
+   * @param request the recognition request containing images or videos to recognize and options
+   * @return a list of results, one for each image or video
+   * @throws ClarifaiException on errors; the class of the exception indicates the kind of error
+   */
+  public List<RecognitionResult> recognizeTag(RecognitionRequest request) throws ClarifaiException {
+    return Arrays.asList(new ClarifaiRequester<RecognitionResult[]>(
+        connectionFactory, credentialManager, POST, "/tag", RecognitionResult[].class,
+        maxAttempts)
+        .execute(request));
+  }
+
+  /**
    * Makes a feedback request.
    * @param request the feedback request
    * @throws ClarifaiException on errors; the class of the exception indicates the kind of error

--- a/src/main/java/com/clarifai/api/ClarifaiClient.java
+++ b/src/main/java/com/clarifai/api/ClarifaiClient.java
@@ -95,7 +95,7 @@ public class ClarifaiClient {
    * @return a list of results, one for each image or video
    * @throws ClarifaiException on errors; the class of the exception indicates the kind of error
    */
-  public List<RecognitionResult> recognizeTag(RecognitionRequest request) throws ClarifaiException {
+  public List<RecognitionResult> recognizeTags(RecognitionRequest request) throws ClarifaiException {
     return Arrays.asList(new ClarifaiRequester<RecognitionResult[]>(
         connectionFactory, credentialManager, POST, "/tag", RecognitionResult[].class,
         maxAttempts)

--- a/src/main/java/com/clarifai/api/RecognitionRequest.java
+++ b/src/main/java/com/clarifai/api/RecognitionRequest.java
@@ -43,6 +43,7 @@ public class RecognitionRequest extends ClarifaiRequest {
   }
 
   private final List<Item> items = new ArrayList<Item>();
+  private final List<String> selectClasses = new ArrayList<String>();
   private String model = "default";
   private Locale locale = null;
   private final Set<String> operations = defaultOperations();
@@ -155,6 +156,12 @@ public class RecognitionRequest extends ClarifaiRequest {
     return this;
   }
 
+  /** Add a tag for which you'd like to get the probability of for the image. */
+  public RecognitionRequest addTagForSelectClasses(String tag) {
+    selectClasses.add(tag);
+    return this;
+  }
+
   @Override String getContentType() {
     return "multipart/form-data; boundary=" + multipart.getBoundary();
   }
@@ -195,6 +202,15 @@ public class RecognitionRequest extends ClarifaiRequest {
         }
       }
     }
+
+    if (selectClasses.size() > 0) {
+      StringBuilder joined = new StringBuilder(selectClasses.get(0));
+      for (int i = 1; i < selectClasses.size(); i++) {
+        joined.append(',').append(selectClasses.get(i));
+      }
+      multipart.writeParameter("select_classes", joined.toString());
+    }
+
     multipart.finish();
   }
 }

--- a/src/main/java/com/clarifai/api/RecognitionRequest.java
+++ b/src/main/java/com/clarifai/api/RecognitionRequest.java
@@ -156,7 +156,9 @@ public class RecognitionRequest extends ClarifaiRequest {
     return this;
   }
 
-  /** Add a tag for which you'd like to get the probability of for the image. */
+  /** Add a tag for which you'd like to get the probability of for the image.
+   *  @see <a href="https://developer.clarifai.com/guide/tag#select-classes">Select Classes Documentation</a>
+   */
   public RecognitionRequest addTagForSelectClasses(String tag) {
     selectClasses.add(tag);
     return this;

--- a/src/test/java/com/clarifai/api/ClarifaiClientServerTest.java
+++ b/src/test/java/com/clarifai/api/ClarifaiClientServerTest.java
@@ -82,7 +82,7 @@ public class ClarifaiClientServerTest {
   @Test public void testRecognizeWithSelectClasses() {
     if (shouldSkipTest()) return;
 
-    List<RecognitionResult> results = clarifai.recognize(new RecognitionRequest(
+    List<RecognitionResult> results = clarifai.recognizeTag(new RecognitionRequest(
 	        "http://www.clarifai.com/img/metro-north.jpg").addTagForSelectClasses("cookie"));
 
     assertThat(results.size(), equalTo(1));

--- a/src/test/java/com/clarifai/api/ClarifaiClientServerTest.java
+++ b/src/test/java/com/clarifai/api/ClarifaiClientServerTest.java
@@ -79,6 +79,22 @@ public class ClarifaiClientServerTest {
     assertThat(result.getEmbedding(), nullValue());
   }
 
+  @Test public void testRecognizeWithSelectClasses() {
+    if (shouldSkipTest()) return;
+
+    List<RecognitionResult> results = clarifai.recognize(new RecognitionRequest(
+	        "http://www.clarifai.com/img/metro-north.jpg").addTagForSelectClasses("cookie"));
+
+    assertThat(results.size(), equalTo(1));
+    RecognitionResult result = results.get(0);
+    assertThat(result.getStatusCode(), equalTo(StatusCode.OK));
+    assertThat(result.getDocId(), equalTo("31fdb2316ff87fb5d747554ba5267313"));
+    assertThat(findTag(result.getTags(), "cookie"), notNullValue());
+    assertThat(findTag(result.getTags(), "cookie").getProbability(), greaterThan(0.0));
+    assertThat(findTag(result.getTags(), "cookie").getProbability(), lessThan(1.0));
+    assertThat(result.getEmbedding(), nullValue());
+  }
+
   @Test public void testRecognizeMultiple() throws IOException {
     if (shouldSkipTest()) return;
 

--- a/src/test/java/com/clarifai/api/ClarifaiClientServerTest.java
+++ b/src/test/java/com/clarifai/api/ClarifaiClientServerTest.java
@@ -82,7 +82,7 @@ public class ClarifaiClientServerTest {
   @Test public void testRecognizeWithSelectClasses() {
     if (shouldSkipTest()) return;
 
-    List<RecognitionResult> results = clarifai.recognizeTag(new RecognitionRequest(
+    List<RecognitionResult> results = clarifai.recognizeTags(new RecognitionRequest(
 	        "http://www.clarifai.com/img/metro-north.jpg").addTagForSelectClasses("cookie"));
 
     assertThat(results.size(), equalTo(1));


### PR DESCRIPTION
I wanted to be able to use select_classes to check for a specific tag on my images. https://developer.clarifai.com/guide/tag#select-classes

Unfortunately select_classes only works for the ```/tags``` endpoint, and not the ```/multiop``` endpoint, from what I can tell. This means I had to add a new client method for recognizeTags. I'd be glad to hear alternatives.

My new test is green. The other unit tests were failing for me on install, so I assumed that was an environmental issue or a problem with the permissions on my account.

Fixes #9 