### PR TITLE
Don't bring in AutoValue as dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ subprojects {
   ext.versions = [
       okhttp: "3.4.1",
       kotlin: "1.0.3",
+      autoValue: "1.3",
 
 //      junit: "5.0.0-M2",
 //      junitPlatform: "1.0.0-M2",
@@ -29,7 +30,8 @@ subprojects {
 
       gson: "com.google.code.gson:gson:2.7",
 
-      autoValue: "com.google.auto.value:auto-value:1.3",
+      autoValue: "com.google.auto.value:auto-value:$versions.autoValue",
+      autoValueAnnotations: "com.jakewharton.auto.value:auto-value-annotations:$versions.autoValue",
 
       nullityAnnotations: "org.jetbrains:annotations:13.0",
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -128,7 +128,7 @@ dependencies {
   )
 
   compileOnly(
-      deps.autoValue,
+      deps.autoValueAnnotations,
       deps.nullityAnnotations,
   )
 


### PR DESCRIPTION
Use Jake Wharton's AutoValueAnnotations project to avoid leaking the entirety of AutoValue's code and dependencies into the user's classpath.

See: https://github.com/JakeWharton/AutoValueAnnotations