### PR TITLE
copy over the gradle example from the quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ Installation
 Add the following to the dependencies section of your `build.gradle`:
 
 ```groovy
-compile 'com.clarifai.clarifai-api2:core:[version]'
+// Add the client to your dependencies:
+dependencies {
+    compile 'com.clarifai.clarifai-api2:core:[version]'
+}
+
+// Make sure you have the Maven Central Repository in your Gradle File
+repositories {
+    mavenCentral()
+}
 ```
 
 ### Maven:


### PR DESCRIPTION
Quick start's example is better than the one in README.md:
https://developer.clarifai.com/quick-start/